### PR TITLE
Improve caps lock toggle

### DIFF
--- a/keylistener/keylistener/keylistener.js
+++ b/keylistener/keylistener/keylistener.js
@@ -44,9 +44,11 @@ angular.module('keyListener', ['servoy']).factory("keyListener", function($servi
 					handleKeyEvent(event);
 				}),
 				$element.keydown(function(event) {
-					if (event.keyCode === 20) {
-						// handle caps lock keyevent exceptions:
-						// ON in Chrome, ON/OFF in Firefox
+					if (event.keyCode === 20 && navigator.appVersion.indexOf("Mac")!=-1) {
+						// handle caps lock keyevent exceptions on Mac:
+						// keydown is triggered in case of toggle to ON in Safari/Chrome, ON/OFF in Firefox
+						// Windows does handle both ON/OFF in the keyup event
+						
 						handleKeyEvent(event);
 					}
 				})

--- a/keylistener/keylistener/keylistener.js
+++ b/keylistener/keylistener/keylistener.js
@@ -41,6 +41,17 @@ angular.module('keyListener', ['servoy']).factory("keyListener", function($servi
 			restrict: 'A',
 			controller: function($scope, $element, $attrs) {
 				$element.keyup(function(event) {
+					handleKeyEvent(event);
+				}),
+				$element.keydown(function(event) {
+					if (event.keyCode === 20) {
+						// handle caps lock keyevent exceptions:
+						// ON in Chrome, ON/OFF in Firefox
+						handleKeyEvent(event);
+					}
+				})
+				
+				function handleKeyEvent(event) {
 					var callback = keyListener.getCallback($attrs.keylistener);
 					if (callback) {
 						var input;
@@ -69,7 +80,7 @@ angular.module('keyListener', ['servoy']).factory("keyListener", function($servi
 					    var jsEvent = $utils.createJSEvent(event, 'action'); 
 						$window.executeInlineScript(callback.formname, callback.script, [input.val(), jsEvent, event.keyCode, event.altKey, event.ctrlKey, event.shiftKey, capsLockEnabled]);
 					}
-				})
+				}
 			}
 		};
 	})


### PR DESCRIPTION
Included keydown event in order to handle caps lock key event in some browsers (both ON and OFF, instead of only OFF or not at all) > see: https://stackoverflow.com/questions/39016292/keydown-event-is-not-fired-for-capslock-in-mac