### PR TITLE
Only remove callbacks with given callback key when adding new keylistener

### DIFF
--- a/keylistener/projects/keylistener/src/keylistener/keylistener.service.ts
+++ b/keylistener/projects/keylistener/src/keylistener/keylistener.service.ts
@@ -70,7 +70,9 @@ export class KeyListener implements IComponentContributorListener {
     }
 
     public addKeyListener(callbackKey: string, callback: (...args: unknown[]) => void, clearCB?: boolean, delay?: number, regexPattern?: string, regexReplacement?: string) {
-        if (clearCB) this._callbacks = [];
+        if (clearCB) {
+            this._callbacks = this._callbacks.filter(c => c.callbackKey !== callbackKey);
+        }
         this._callbacks.push({ callbackKey, callback, delay, regexPattern, regexReplacement });
         this.servoyService.sendServiceChanges('keyListener', 'callbacks', this._callbacks);
     }


### PR DESCRIPTION
When adding a keylistener that should replace a previous keylistener, instead of replacing just the previous keylistener with the same callbackKey it replaces all keylisteners.